### PR TITLE
export styled components directly

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,14 +1,12 @@
-import * as React from 'react'
 import styled from 'styled-components'
 
 interface StyledButtonProps {
   primary?: boolean
   danger?: boolean
   fillWidth?: boolean
-  children: React.ReactNode
 }
 
-const ButtonWrapper = styled.button`
+const Button = styled.button`
   background: ${(props: StyledButtonProps) =>
     props.primary ? 'grey' : 'white'};
   width: ${(props: StyledButtonProps) => (props.fillWidth ? '100%' : 'auto')};
@@ -27,7 +25,4 @@ const ButtonWrapper = styled.button`
   }
 `
 
-export default function Button(props: StyledButtonProps) {
-  const { children, ...styledProps } = props
-  return <ButtonWrapper {...styledProps}>{props.children}</ButtonWrapper>
-}
+export default Button

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react'
 import styled from 'styled-components'
 
-const CardWrapper = styled.div`
+const Card = styled.div`
   padding: 1.25em;
   border-radius: 5px;
   border: solid #e1e1e1 1px;
@@ -11,17 +10,5 @@ const CardWrapper = styled.div`
     cursor: pointer;
   }
 `
-
-interface CardProps {
-  children: React.ReactNode
-}
-
-const Card: React.SFC = (props: CardProps) => {
-  return (
-    <div>
-      <CardWrapper>{props.children}</CardWrapper>
-    </div>
-  )
-}
 
 export default Card

--- a/frontend/src/components/Typography.tsx
+++ b/frontend/src/components/Typography.tsx
@@ -1,58 +1,22 @@
-import * as React from 'react'
 import styled from 'styled-components'
 
-const HeaderWrapper = styled.div`
+export const Header = styled.div`
   font-size: 1.5em;
   font-weight: 700;
+  font-family: Cabin;
   margin: 0.8125em 0;
 `
 
-interface HeaderProps {
-  children: React.ReactNode
-}
-
-const Header: React.SFC = (props: HeaderProps) => {
-  return (
-    <div>
-      <HeaderWrapper>{props.children}</HeaderWrapper>
-    </div>
-  )
-}
-
-const SubheaderWrapper = styled.div`
+export const Subheader = styled.div`
   font-size: 1em;
   font-weight: 700;
+  font-family: Cabin;
   margin: 0.75em 0;
 `
 
-interface SubheaderProps {
-  children: React.ReactNode
-}
-
-const Subheader: React.SFC = (props: SubheaderProps) => {
-  return (
-    <div>
-      <SubheaderWrapper>{props.children}</SubheaderWrapper>
-    </div>
-  )
-}
-
-const ParagraphWrapper = styled.div`
+export const Paragraph = styled.div`
   font-size: 1em;
   font-weight: 400;
+  font-family: Cabin;
   margin: 0.75em 0;
 `
-
-interface ParagraphProps {
-  children: React.ReactNode
-}
-
-const Paragraph: React.SFC = (props: ParagraphProps) => {
-  return (
-    <div>
-      <ParagraphWrapper>{props.children}</ParagraphWrapper>
-    </div>
-  )
-}
-
-export { Header, Subheader, Paragraph }

--- a/frontend/src/components/Wrapper.tsx
+++ b/frontend/src/components/Wrapper.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react'
 import styled from 'styled-components'
 
-const TextWrapper = styled.div`
+const Wrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   grid-template-rows: repeat(6, 1fr);
@@ -10,17 +9,5 @@ const TextWrapper = styled.div`
   font-style: normal;
   line-height: normal;
 `
-
-interface WrapperProps {
-  children: React.ReactNode
-}
-
-const Wrapper: React.SFC = (props: WrapperProps) => {
-  return (
-    <div>
-      <TextWrapper>{props.children}</TextWrapper>
-    </div>
-  )
-}
 
 export default Wrapper

--- a/frontend/src/containers/Home/index.tsx
+++ b/frontend/src/containers/Home/index.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import Button from '../../components/Button'
+import { Header } from '../../components/Typography'
 
 class Home extends React.Component {
   render() {
     return (
       <div>
-        <div>Hello World</div>
+        <Header>Hello World</Header>
         <Button>Confirm</Button>
         <Button primary>Primary</Button>
         <Button fillWidth>Fill</Button>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,8 +3,6 @@
   <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width">
-    <link href="https://fonts.googleapis.com/css?family=Karla" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Cabin" rel="stylesheet">
     <script src="https://apis.google.com/js/platform.js" async defer></script>
     <title>Schedular</title>


### PR DESCRIPTION
Rather than create and export React components that wrap the styled component, we can export the styled components directly for use. 

@justinjeon @chloe-jiang There isn't much to this PR, but please look through the changes. I should've caught this in your previous PRs